### PR TITLE
fix: calculate atlas size with buffer width added

### DIFF
--- a/examples/test_pack.rs
+++ b/examples/test_pack.rs
@@ -54,11 +54,7 @@ fn main() {
     }
 
     // initialize texture packer
-    let config = TexturePlacerConfig {
-        width: 4096,
-        height: 4096,
-        padding: 0,
-    };
+    let config = TexturePlacerConfig::new(4096, 4096, 0, 2);
 
     let packer = Mutex::new(AtlasPacker::default());
 

--- a/examples/test_random_polygon.rs
+++ b/examples/test_random_polygon.rs
@@ -91,11 +91,7 @@ fn main() {
     }
 
     // initialize texture packer
-    let config = TexturePlacerConfig {
-        width: 4096,
-        height: 4096,
-        padding: 0,
-    };
+    let config = TexturePlacerConfig::new(4096, 4096, 0, 2);
 
     let packer = Mutex::new(AtlasPacker::default());
 
@@ -140,7 +136,7 @@ fn main() {
         count += 1;
         if let Some(info) = packed.get_texture_info(&polygon.id) {
             let pixel_coords =
-                uv_to_pixel_coords(&info.placed_uv_coords, config.width, config.height);
+                uv_to_pixel_coords(&info.placed_uv_coords, config.width(), config.height());
 
             let tex_bbox = calc_bbox(&pixel_coords);
 

--- a/examples/test_unused_pixels.rs
+++ b/examples/test_unused_pixels.rs
@@ -14,7 +14,7 @@ use utils::unused_pixels;
 fn main() {
     let texture_cache = TextureCache::new(100_000_000);
 
-    let config = TexturePlacerConfig::new(500, 500, 1);
+    let config = TexturePlacerConfig::new(500, 500, 1, 2);
 
     let packer = AtlasPacker::default();
     let packed = packer.pack(GuillotineTexturePlacer::new(config.clone()));

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -243,17 +243,45 @@ mod tests {
         // User creates an atlas packer (no hidden buffer anymore!)
         let mut packer = AtlasPacker::default();
 
+        let width = 1024;
+        let height = 1024;
         // User adds a texture that is exactly 1024x1024
         let texture = PolygonMappedTexture::new(
             Path::new("test.png"),
-            (1024, 1024),
+            (width, height),
             &[(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)],
             DownsampleFactor::new(&1.0),
         );
         packer.add_texture("polygon1".to_string(), texture);
 
         // User creates a placer with 1024x1024 atlas with 2 pixels buffer
-        let placer = GuillotineTexturePlacer::new(TexturePlacerConfig::new(1024, 1024, 0, 2));
+        let buffer = 2;
+        let placer = GuillotineTexturePlacer::new(TexturePlacerConfig::new_padded(width, height, 0, buffer));
+        packer.pack(placer);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_placing_same_size_without_buffer() {
+        // User creates an atlas packer (no hidden buffer anymore!)
+        let mut packer = AtlasPacker::default();
+
+        let width = 1024;
+        let height = 1024;
+        // User adds a texture that is exactly 1024x1024
+        let texture = PolygonMappedTexture::new(
+            Path::new("test.png"),
+            (width, height),
+            &[(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)],
+            DownsampleFactor::new(&1.0),
+        );
+        packer.add_texture("polygon1".to_string(), texture);
+
+        // User creates a placer with 1024x1024 atlas with 2 pixels buffer without reserving space for buffer
+        let buffer = 2;
+        let atlas_width = width;
+        let atlas_height = height;
+        let placer = GuillotineTexturePlacer::new(TexturePlacerConfig::new(atlas_width, atlas_height, 0, buffer));
         packer.pack(placer);
     }
 }

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -256,7 +256,8 @@ mod tests {
 
         // User creates a placer with 1024x1024 atlas with 2 pixels buffer
         let buffer = 2;
-        let placer = GuillotineTexturePlacer::new(TexturePlacerConfig::new_padded(width, height, 0, buffer));
+        let placer =
+            GuillotineTexturePlacer::new(TexturePlacerConfig::new_padded(width, height, 0, buffer));
         packer.pack(placer);
     }
 
@@ -281,7 +282,12 @@ mod tests {
         let buffer = 2;
         let atlas_width = width;
         let atlas_height = height;
-        let placer = GuillotineTexturePlacer::new(TexturePlacerConfig::new(atlas_width, atlas_height, 0, buffer));
+        let placer = GuillotineTexturePlacer::new(TexturePlacerConfig::new(
+            atlas_width,
+            atlas_height,
+            0,
+            buffer,
+        ));
         packer.pack(placer);
     }
 }

--- a/src/place.rs
+++ b/src/place.rs
@@ -7,30 +7,35 @@ use crate::{
 
 #[derive(Debug, Clone)]
 pub struct TexturePlacerConfig {
-    pub width: u32,
-    pub height: u32,
-    pub padding: u32,
+    width: u32,
+    height: u32,
+    padding: u32,
+    buffer: u32,
     // and more option
     // Allow rotation, allow multiple pages, adjust resolution, specify resampling method, etc...
 }
 
 impl Default for TexturePlacerConfig {
     fn default() -> Self {
-        TexturePlacerConfig {
-            width: 1024,
-            height: 1024,
-            padding: 0,
-        }
+        Self::new(1024, 1024, 0, 2)
     }
 }
 
 impl TexturePlacerConfig {
-    // Ensure that the width and height are powers of two
-    pub fn new(width: u32, height: u32, padding: u32) -> Self {
+    // User provides max texture size, we calculate atlas size including buffer and padding
+    pub fn new(max_texture_width: u32, max_texture_height: u32, padding: u32, buffer: u32) -> Self {
+        let width = (max_texture_width + buffer * 2 + padding * 2)
+            .checked_next_power_of_two()
+            .unwrap();
+        let height = (max_texture_height + buffer * 2 + padding * 2)
+            .checked_next_power_of_two()
+            .unwrap();
+
         TexturePlacerConfig {
-            width: width.checked_next_power_of_two().unwrap(),
-            height: height.checked_next_power_of_two().unwrap(),
+            width,
+            height,
             padding,
+            buffer,
         }
     }
 
@@ -44,6 +49,10 @@ impl TexturePlacerConfig {
 
     pub fn padding(&self) -> u32 {
         self.padding
+    }
+
+    pub fn buffer(&self) -> u32 {
+        self.buffer
     }
 }
 

--- a/src/place.rs
+++ b/src/place.rs
@@ -11,8 +11,6 @@ pub struct TexturePlacerConfig {
     height: u32,
     padding: u32,
     buffer: u32,
-    // and more option
-    // Allow rotation, allow multiple pages, adjust resolution, specify resampling method, etc...
 }
 
 impl Default for TexturePlacerConfig {
@@ -22,6 +20,7 @@ impl Default for TexturePlacerConfig {
 }
 
 impl TexturePlacerConfig {
+    // create a TexturePlacerConfig taking exact atlas size
     pub fn new(width: u32, height: u32, padding: u32, buffer: u32) -> Self {
         TexturePlacerConfig {
             width: width.checked_next_power_of_two().unwrap(),
@@ -31,6 +30,7 @@ impl TexturePlacerConfig {
         }
     }
 
+    // Creates a TexturePlacerConfig taking max allowed texture size
     pub fn new_padded(
         max_texture_width: u32,
         max_texture_height: u32,

--- a/src/place.rs
+++ b/src/place.rs
@@ -31,7 +31,12 @@ impl TexturePlacerConfig {
         }
     }
 
-    pub fn new_padded(max_texture_width: u32, max_texture_height: u32, padding: u32, buffer: u32) -> Self {
+    pub fn new_padded(
+        max_texture_width: u32,
+        max_texture_height: u32,
+        padding: u32,
+        buffer: u32,
+    ) -> Self {
         let atlas_width = max_texture_width + padding * 2 + buffer * 2;
         let atlas_height = max_texture_height + padding * 2 + buffer * 2;
         Self::new(atlas_width, atlas_height, padding, buffer)

--- a/src/place.rs
+++ b/src/place.rs
@@ -22,21 +22,19 @@ impl Default for TexturePlacerConfig {
 }
 
 impl TexturePlacerConfig {
-    // User provides max texture size, we calculate atlas size including buffer and padding
-    pub fn new(max_texture_width: u32, max_texture_height: u32, padding: u32, buffer: u32) -> Self {
-        let width = (max_texture_width + buffer * 2 + padding * 2)
-            .checked_next_power_of_two()
-            .unwrap();
-        let height = (max_texture_height + buffer * 2 + padding * 2)
-            .checked_next_power_of_two()
-            .unwrap();
-
+    pub fn new(width: u32, height: u32, padding: u32, buffer: u32) -> Self {
         TexturePlacerConfig {
-            width,
-            height,
+            width: width.checked_next_power_of_two().unwrap(),
+            height: height.checked_next_power_of_two().unwrap(),
             padding,
             buffer,
         }
+    }
+
+    pub fn new_padded(max_texture_width: u32, max_texture_height: u32, padding: u32, buffer: u32) -> Self {
+        let atlas_width = max_texture_width + padding * 2 + buffer * 2;
+        let atlas_height = max_texture_height + padding * 2 + buffer * 2;
+        Self::new(atlas_width, atlas_height, padding, buffer)
     }
 
     pub fn width(&self) -> u32 {


### PR DESCRIPTION
## Overview

Currently, packer has a `buffer` field which cannot be read or written from caller side. This is problematic because users are expected to manually create an atlas slightly bigger than the largest texture (2x buffer), but since the buffer size is unknown, it is not possible to calculate the size safely.

This PR fixes this problem by moving buffer field from packer to placer, and automatically adds the buffer size to atlas dimension during initialization.

## Changes

- Move `buffer` field from `AtlasPacker` to `TexturePlacerConfig`. `buffer` is a placer parameter (added around each cluster, not whole atlas), not a packer parameter.
- Add a `new_padded()` initialization function which takes max allowed texture size. The atlas size is padded with 2x(buffer + padding).
- Make `TexturePlacerConfig` members private since users should not adjust these values during packing.
- Add unit tests to reflect the problem and the fix.

## Additional notes

- I think padding is probably not necessary because the cluster isolation can be fully provided by buffer. Currently all examples and use cases set padding to zero.
- Inherently atlasing is a traditional method and will have problem with wrapping samplers, mipmaps, etc., which cannot be solved by buffering.
- Maybe we should convert these example tests into unit tests.
- This crate contains manual pixel copies and unnecessary parallelizations that can be optimized. Examples:
  - https://github.com/reearth/atlas-packer/blob/91c9449caab3e16d77d2bbb312386386bbf68c9f/src/export.rs#L156
  - https://github.com/reearth/atlas-packer/blob/91c9449caab3e16d77d2bbb312386386bbf68c9f/src/export.rs#L167
  - https://github.com/reearth/atlas-packer/blob/91c9449caab3e16d77d2bbb312386386bbf68c9f/src/texture/mod.rs#L174
- Buffer and `next_power_of_2` may cause 4x texture size since most provided textures are already power of 2. The buffered texture will have sizes like 1028x1028 which requires a 2048x2048 texture. This problem should be handled from user size (detect large textures to exclude them from atlas builing).